### PR TITLE
Skip integer parameters without throwing an error

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6,7 +6,7 @@ const bluebird = require('bluebird');
 const readEnvFile = (path = '.env') => fs.readFileSync(path, { encoding: 'utf-8' }).trim().split('\n')
 
 const checkParam = (envValue) => {
-  if (envValue === undefined || envValue.startsWith('${ssm:')) {
+  if (envValue === undefined || (typeof envValue === 'string' &&  envValue.startsWith('${ssm:'))) {
     return true;
   }
 

--- a/src/__test__/checkParam.test.js
+++ b/src/__test__/checkParam.test.js
@@ -8,6 +8,10 @@ it('doesn\'t allow non ssm params', () => {
   expect(checkParam('FOO')).toBeFalsy()
 })
 
+it('doesn\'t allow integer params', () => {
+  expect(checkParam(2345)).toBeFalsy()
+})
+
 it('also checks if the param is undefined', () => {
   expect(checkParam(undefined)).toBeTruthy()
 })

--- a/src/checkParam.js
+++ b/src/checkParam.js
@@ -1,5 +1,5 @@
 export default (envValue) => {
-  if (envValue === undefined || envValue.startsWith('${ssm:')) {
+  if (envValue === undefined || (typeof envValue === 'string' &&  envValue.startsWith('${ssm:'))) {
     return true;
   }
 


### PR DESCRIPTION
When specifying an integer environment variable, `checkParams` would throw an error and all subsequent replacements would fail.

I've added handling for non-string parameters, and added a test that would fail without this change.