### PR TITLE
Fix crash when provider environment is null

### DIFF
--- a/src/__test__/start.test.js
+++ b/src/__test__/start.test.js
@@ -19,3 +19,19 @@ it('updates the serverless config env vars', async () => {
   expect(serverless.service.provider.environment.ENV_VAR).toBe('FOO')
   expect(serverless.service.provider.environment.STAGE).toBe('${opt:stage, self:provider.stage}') // eslint-disable-line
 })
+
+it('runs when the environment is null', async () => {
+  const serverlessNullEnv = {
+    cli: {
+      log: jest.fn(),
+    },
+    service: {
+      provider: {
+        environment: null
+      }
+    }
+  }
+
+  await start(serverlessNullEnv)
+  expect(serverlessNullEnv.service.provider.environment).toBeNull()
+})

--- a/src/start.js
+++ b/src/start.js
@@ -7,7 +7,7 @@ export default serverless => new Promise(resolve => {
     const sv = serverless
     const { environment } = serverless.service.provider
 
-    Object.keys(environment).forEach(key => {
+    Object.keys(environment || {}).forEach(key => {
       if (checkParam(environment[key])) {
 
         lines.forEach(line => {


### PR DESCRIPTION
When the `environment` field is omitted from the `provider` in the `serverless.yml` file, it is given to the plugin as `null`, which causes a crash when checking it with `Object.keys`. This patch fixes this by passing in an empty object if the environment is null.

Test is included. When the test is run without the fix, the test fails. When the test is run with the fix, the test passes.