### PR TITLE
Add support for environment variables in functions

### DIFF
--- a/src/__test__/start.test.js
+++ b/src/__test__/start.test.js
@@ -35,3 +35,38 @@ it('runs when the environment is null', async () => {
   await start(serverlessNullEnv)
   expect(serverlessNullEnv.service.provider.environment).toBeNull()
 })
+
+it('updates the serverless config function env vars', async () => {
+  const serverlessFnEnv = {
+    cli: {
+      log: jest.fn(),
+    },
+    service: {
+      provider: {
+        environment: {
+          ENV_VAR: 'FOO'
+        }
+      },
+      functions: {
+        test1: {
+          environment: {
+            STAGE: '${opt:stage, self:provider.stage}', // eslint-disable-line
+            ENV_VAR: '${ssm:ENV_VAR}' // eslint-disable-line
+          }
+        },
+        test2: {
+          environment: {
+            STAGE: '${opt:stage, self:provider.stage}', // eslint-disable-line
+            ENV_VAR: 'FOO' // eslint-disable-line
+          }
+        }
+      }
+    }
+  }
+
+  await start(serverlessFnEnv)
+  expect(serverlessFnEnv.service.provider.environment.ENV_VAR).toBe('FOO')
+  expect(serverlessFnEnv.service.functions.test1.environment.ENV_VAR).toBe('FOO')
+  expect(serverlessFnEnv.service.functions.test1.environment.STAGE).toBe('${opt:stage, self:provider.stage}') // eslint-disable-line
+  expect(serverlessFnEnv.service.functions.test2.environment.ENV_VAR).toBe('FOO')
+})

--- a/src/start.js
+++ b/src/start.js
@@ -2,26 +2,38 @@ import { Promise } from 'bluebird'
 import readEnvFile from './envFile'
 import checkParam from './checkParam'
 
+const updateEnvironment = (provider, lines, serverless, debugName) => {
+  const { environment } = provider
+
+  Object.keys(environment || {}).forEach(key => {
+    if (checkParam(environment[key])) {
+
+      lines.forEach(line => {
+        const [envKey, value] = line.split(/=(.*)/)
+
+        if (envKey === key) {
+          serverless.cli.log(`Setting '${debugName}' Variable ${key} to ${value}`)
+
+          environment[key] = value
+        }
+      })
+    }
+  })
+
+  const updatedProvider = provider
+  updatedProvider.environment = environment
+  return updatedProvider
+}
+
 export default serverless => new Promise(resolve => {
     const lines = readEnvFile()
     const sv = serverless
-    const { environment } = serverless.service.provider
 
-    Object.keys(environment || {}).forEach(key => {
-      if (checkParam(environment[key])) {
-
-        lines.forEach(line => {
-          const [envKey, value] = line.split(/=(.*)/)
-
-          if (envKey === key) {
-            serverless.cli.log(`Setting Variable ${key} to ${value}`)
-
-            environment[key] = value
-          }
-        })
-      }
+    sv.service.provider = updateEnvironment(sv.service.provider, lines, sv, `Service`)
+    Object.keys(sv.service.functions || []).forEach(functionName => {
+      const functionFields = sv.service.functions[functionName]
+      sv.service.functions[functionName] = updateEnvironment(functionFields, lines, sv, `Function ${functionName}`)
     })
-    sv.service.provider.environment = environment
 
     return resolve()
 })


### PR DESCRIPTION
https://serverless.com/framework/docs/providers/aws/guide/functions/

The Serverless framework supports environment variables in functions as well as the service provider itself. This PR adds support for applying .env variables to functions.

I moved some of the logic of the start.js file into a separate function and use that multiple times. I'm totally open to alternatives to this approach.

There's also a test case added for it.

Thanks for your consideration!