### PR TITLE
Enable plugin on print command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,10 @@ class ServerlessOfflineSSM {
     if (commands[0] === 'invoke' && commands[1] === 'local') {
       return true
     }
+    
+    if (commands[0] === 'print') {
+      return true
+    }
 
     return false
   }


### PR DESCRIPTION
To be able to debug my serverless.yml parameters, I used to run `serverless print` command.
It could be useful to enable this plugin also for this command.

Thanks for this great plugin !