### PR TITLE
Parse value as JSON for AWS Secrets Manager keys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,9 +70,9 @@ class ServerlessOfflineSSM implements Plugin {
     
     if (key.startsWith('/aws/reference/secretsmanager')) {
       return promisifiedValue.then(JSON.parse).catch(() => promisifiedValue)
-    } else {
-      return promisifiedValue
-    }
+    } 
+
+    return promisifiedValue
   }
 
   shouldExecute = (): boolean => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,15 @@ class ServerlessOfflineSSM implements Plugin {
     }
 
     const value = this.config.ssm?.[key]
-    return value ? Promise.resolve(value) : getValueFromEnv(key)
+    const promisifiedValue = value
+      ? Promise.resolve(value)
+      : getValueFromEnv(key)
+    
+    if (key.startsWith('/aws/reference/secretsmanager')) {
+      return promisifiedValue.then(JSON.parse).catch(() => promisifiedValue)
+    } else {
+      return promisifiedValue
+    }
   }
 
   shouldExecute = (): boolean => {


### PR DESCRIPTION
Added support for AWS Secrets Manager object values #58 by parsing the value as JSON for keys that start with `       /aws/reference/secretsmanager`.

See [Variables.js](https://github.com/serverless/serverless/blob/master/lib/classes/Variables.js#L843) in the serverless project for how serverless parses these objects
