### PR TITLE
Enable configuring stages from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ or provider sections of your `serverless.yaml` are includes within the
 `stages` property of the plugin configuration. If this condition has not been
 met the plugin has no effect.
 
+The `stages` property of the plugin configuration can be overridden with a
+cli parameter `--ssmOfflineStages` which takes a comma separated list of
+stages.
+
 ### .env
 
 Your `.env` file needs to contain only variable names without the `ssm:` prefix and `~(true|false|split)` sulfix.

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -74,6 +74,23 @@ describe('serverless-offline-ssm', () => {
     expect(serverless.variables.variableResolvers[0].resolver).not.toEqual(instance.resolver)
   })
 
+  test('should initialize with ssmOfflineStages passed to the CLI', () => {
+    const serverless = serverlessMock({
+      service: {
+        custom: {
+          'serverless-offline-ssm': {
+            stages: null,
+          },
+        },
+      },
+    })
+    const options = serverlessOptionsMock({ ssmOfflineStages: stage })
+    const instance = new ServerlessOfflineSSM(serverless, options)
+
+    // check the resolver has been overridden
+    expect(serverless.variables.variableResolvers[0].resolver).toEqual(instance.resolver)
+  })
+
   test('throws an exception with an invalid serverless version', () => {
     expect(() => new ServerlessOfflineSSM(
       serverlessMock({ version: '0.99'}),

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,10 @@ type ServerlessOffline = Serverless & {
   }
 }
 
+type PluginOptions = Serverless.Options & {
+  ssmOfflineStages?: string
+}
+
 class ServerlessOfflineSSM implements Plugin {
   private log: (message: string) => null
   private config?: ServerlessOfflineSSMConfig
@@ -31,10 +35,13 @@ class ServerlessOfflineSSM implements Plugin {
 
   constructor(
     private serverless: ServerlessOffline,
-    private options: Serverless.Options
+    private options: PluginOptions
   ) {
     this.log = serverless.cli.log.bind(serverless.cli)
     this.config = serverless.service.custom?.['serverless-offline-ssm'] ?? {}
+    if (!!options.ssmOfflineStages) {
+      this.config.stages = options.ssmOfflineStages.split(',')
+    }
     this.provider = 'aws'
 
     // check for valid configuration


### PR DESCRIPTION
We want to be able to configure which stages this plugin should be
enabled for dynamically.

Our use case: we want to package our app offline for a stage that will
normally use real the real SSM resolver in CI builds.

This solves #48 in a indirect way.